### PR TITLE
Don't return None from client()

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ pip install statsdecor
 
 ## Configuration
 
-You can use `statsdecor.configure` to configure how statsd clients will be
-created:
+You must use `statsdecor.configure` to configure the internal statsd client before
+calling other methods:
 
 ```python
 import statsdecor

--- a/statsdecor/__init__.py
+++ b/statsdecor/__init__.py
@@ -37,6 +37,8 @@ def client():
     For the code, see
     https://github.com/jsocol/pystatsd/blob/master/statsd/client.py
     """
+    if _stats_client is None:
+        configure({})
     return _stats_client
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,5 +1,14 @@
 import statsdecor
+import statsd
 from tests.conftest import stub_client
+
+
+def test_client_error_no_config(monkeypatch):
+    # When the client hasn't been initialized,
+    # an exception should be raised by client()
+    monkeypatch.setattr(statsdecor, '_stats_client', None)
+    client = statsdecor.client()
+    assert isinstance(client, statsd.StatsClient)
 
 
 def test_incr():


### PR DESCRIPTION
When the client is configured we shouldn't return None and effectively break the entire package. Instead make an unconfigured client which is better than None.