### PR TITLE
Add opt-in support for datadog client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 statsd==3.2.1
+datadog==0.20.0
+future==0.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-statsd==3.2.1
-datadog==0.20.0
-future==0.16.0
+statsd>=3.2.1, <=3.2.2
+datadog>=0.17.0, <=0.20.0

--- a/statsdecor/__init__.py
+++ b/statsdecor/__init__.py
@@ -16,9 +16,9 @@ def _create_client(**config):
         client_config = _create_client_config(config, {'host', 'port'})
         client_config.update(namespace=config.get('prefix')) if config.get('prefix') else None
         return DogStatsdClient(**client_config)
-    else:
-        client_config = _create_client_config(config, {'host', 'port', 'prefix', 'maxudpsize'})
-        return StatsdClient(**client_config)
+
+    client_config = _create_client_config(config, {'host', 'port', 'prefix', 'maxudpsize'})
+    return StatsdClient(**client_config)
 
 def _create_client_config(raw_config, whitelist_fields):
     client_config = {

--- a/statsdecor/__init__.py
+++ b/statsdecor/__init__.py
@@ -1,11 +1,30 @@
-import statsd
 import logging
-
+from statsdecor.clients import (
+    DogStatsdClient,
+    StatsdClient
+)
 
 log = logging.getLogger(__name__)
 _config = {}
 _stats_client = None
 
+
+def _create_client(**config):
+    vendor = config.pop('vendor', None)
+
+    if vendor == 'datadog':
+        client_config = _create_client_config(config, {'host', 'port'})
+        client_config.update(namespace=config.get('prefix')) if config.get('prefix') else None
+        return DogStatsdClient(**client_config)
+    else:
+        client_config = _create_client_config(config, {'host', 'port', 'prefix', 'maxudpsize'})
+        return StatsdClient(**client_config)
+
+def _create_client_config(raw_config, whitelist_fields):
+    client_config = {
+        field: raw_config.get(field) for field in whitelist_fields if raw_config.get(field)
+    }
+    return client_config
 
 def configure(*args, **kwargs):
     """Configure the module level statsd client that will
@@ -25,51 +44,44 @@ def configure(*args, **kwargs):
     log.debug('statsd.configure(%s)' % kwargs)
     _config.update(kwargs)
 
-    _stats_client = statsd.StatsClient(**_config)
+    _stats_client = _create_client(**_config)
 
 
 def client():
-    """Get a client instance with the module level configuration.
-
-    For docs on the statsd client, see
-    http://statsd.readthedocs.org/en/latest/types.html
-
-    For the code, see
-    https://github.com/jsocol/pystatsd/blob/master/statsd/client.py
-    """
+    """Get a client instance with the module level configuration."""
     if _stats_client is None:
         configure({})
     return _stats_client
 
 
-def incr(name, value=1, rate=1):
+def incr(name, value=1, rate=1, tags=None):
     """Increment a metric by value.
 
     >>> import statsdecor
     >>> statsdecor.incr('my.metric')
     """
-    client().incr(name, value, rate)
+    client().incr(name, value, rate, tags)
 
 
-def decr(name, value=1, rate=1):
+def decr(name, value=1, rate=1, tags=None):
     """Decrement a metric by value.
 
     >>> import statsdecor
     >>> statsdecor.decr('my.metric')
     """
-    client().decr(name, value, rate)
+    client().decr(name, value, rate, tags)
 
 
-def gauge(name, value, rate=1):
+def gauge(name, value, rate=1, tags=None):
     """Set the value for a gauge.
 
     >>> import statsdecor
     >>> statsdecor.gauge('my.metric', 10)
     """
-    client().gauge(name, value, rate)
+    client().gauge(name, value, rate, tags)
 
 
-def timer(name):
+def timer(name, tags=None):
     """Time a block of code with a context manager.
 
     >>> import statsdecor
@@ -77,12 +89,12 @@ def timer(name):
     >>>     print('Some output')
     Some output
     """
-    return client().timer(name)
+    return client().timer(name, tags)
 
-def timing(name, delta, rate=1):
+def timing(name, delta, rate=1, tags=None):
     """Sends new timing information. `delta` is in milliseconds.
 
     >>> import statsdecor
     >>> statsdecor.timing('my.metric', 314159265359)
     """
-    return client().timing(name, delta, rate)
+    return client().timing(name, delta, rate, tags)

--- a/statsdecor/clients.py
+++ b/statsdecor/clients.py
@@ -58,4 +58,4 @@ class StatsdClient(StatsClient):
 
     def _assert_no_tags(self, tags):
         if tags:
-            raise ValueError('Tagging is not supported by StatsdClient.\n tags: {}'.format(tags))
+            raise ValueError(u'Tagging is not supported by StatsdClient.\n tags: {}'.format(tags))

--- a/statsdecor/clients.py
+++ b/statsdecor/clients.py
@@ -1,0 +1,61 @@
+from datadog import DogStatsd
+from statsd import StatsClient
+
+
+class DogStatsdClient(DogStatsd):
+    """Wrapper for Datadog's DogStatsd client
+
+    For docs on the DogStatsd client, see
+    http://datadogpy.readthedocs.io/en/latest/
+
+    For the code, see
+    https://github.com/DataDog/datadogpy/blob/master/datadog/dogstatsd/base.py
+    """
+    def incr(self, name, value=1, rate=1, tags=None):
+        super(DogStatsdClient, self).increment(metric=name, value=value, tags=tags, sample_rate=rate)
+
+    def decr(self, name, value=1, rate=1, tags=None):
+        super(DogStatsdClient, self).decrement(metric=name, value=value, tags=tags, sample_rate=rate)
+
+    def gauge(self, name, value=1, rate=1, tags=None):
+        super(DogStatsdClient, self).gauge(metric=name, value=value, tags=tags, sample_rate=rate)
+
+    def timing(self, name, value, rate=1, tags=None):
+        super(DogStatsdClient, self).timing(metric=name, value=value, tags=tags, sample_rate=rate)
+
+    def timer(self, name, tags=None):
+        super(DogStatsdClient, self).timed(metric=name, tags=tags)
+
+
+class StatsdClient(StatsClient):
+    """Wrapper for statsd client
+
+    For docs on the statsd client, see
+    http://statsd.readthedocs.org/en/latest/types.html
+
+    For the code, see
+    https://github.com/jsocol/pystatsd/blob/master/statsd/client.py
+    """
+    def incr(self, name, value=1, rate=1, tags=None):
+        self._assert_no_tags(tags)
+        super(StatsdClient, self).incr(stat=name, count=value, rate=rate)
+
+    def decr(self, name, value=1, rate=1, tags=None):
+        self._assert_no_tags(tags)
+        super(StatsdClient, self).decr(stat=name, count=value, rate=rate)
+
+    def gauge(self, name, value=1, rate=1, tags=None):
+        self._assert_no_tags(tags)
+        super(StatsdClient, self).gauge(stat=name, value=value, rate=rate)
+
+    def timing(self, name, value=1, rate=1, tags=None):
+        self._assert_no_tags(tags)
+        super(StatsdClient, self).timing(stat=name, delta=value, rate=rate)
+
+    def timer(self, name, tags=None):
+        self._assert_no_tags(tags)
+        super(StatsdClient, self).timer(stat=name)
+
+    def _assert_no_tags(self, tags):
+        if tags:
+            raise ValueError('Tagging is not supported by StatsdClient.\n tags: {}'.format(tags))

--- a/statsdecor/decorators.py
+++ b/statsdecor/decorators.py
@@ -2,7 +2,7 @@ from functools import wraps
 from statsdecor import client
 
 
-def increment(name):
+def increment(name, tags=None):
     """Function decorator for incrementing a statsd stat whenever
     a function is invoked.
 
@@ -16,13 +16,13 @@ def increment(name):
         def decorator(*args, **kwargs):
             stats = client()
             ret = f(*args, **kwargs)
-            stats.incr(name)
+            stats.incr(name, tags=tags)
             return ret
         return decorator
     return wrap
 
 
-def decrement(name):
+def decrement(name, tags=None):
     """Function decorator for decrementing a statsd stat whenever
     a function is invoked.
 
@@ -36,13 +36,13 @@ def decrement(name):
         def decorator(*args, **kwargs):
             stats = client()
             ret = f(*args, **kwargs)
-            stats.decr(name)
+            stats.decr(name, tags=tags)
             return ret
         return decorator
     return wrap
 
 
-def timed(name):
+def timed(name, tags=None):
     """Function decorator for tracking timing information
     on a function's invocation.
 
@@ -55,7 +55,7 @@ def timed(name):
         @wraps(f)
         def decorator(*args, **kwargs):
             stats = client()
-            with stats.timer(name):
+            with stats.timer(name, tags=tags):
                 return f(*args, **kwargs)
         return decorator
     return wrap

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,9 @@
 from mock import patch, Mock
-from statsd import StatsClient
 
 
-def stub_client(path='statsdecor.client'):
+def stub_client(client_class, path='statsdecor.client'):
     """Factory for StubClient context managers"""
-    return StubClient(path)
+    return StubClient(path, client_class)
 
 
 class StubClient(object):
@@ -12,11 +11,12 @@ class StubClient(object):
     stubbing out the statsd client factory in the
     library.
     """
-    def __init__(self, path):
+    def __init__(self, path, client_class):
         self.patcher = patch(path)
+        self.client_class = client_class
 
     def __enter__(self):
-        self.client = Mock(spec=StatsClient)
+        self.client = Mock(spec=self.client_class)
         stub_func = self.patcher.start()
         stub_func.return_value = self.client
         return self

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,0 +1,116 @@
+import statsdecor
+import pytest
+from mock import patch, Mock
+
+
+DEFAULT_RATE=1
+DEFAULT_VALUE=1
+NO_TAGS = None
+
+
+class TestStatsdDefaultClient(object):
+    def setup(self):
+        self.tags = ['StatsClient_doesnt_do_tags!']
+        statsdecor.configure(vendor='')
+
+    @patch('statsd.client.StatsClient.incr')
+    def test_incr_no_tag(self, mocked_super):
+        statsdecor.incr('a.metric')
+        mocked_super.assert_called_with(stat='a.metric', count=DEFAULT_VALUE, rate=DEFAULT_RATE)
+
+    def test_incr_with_tag(self):
+        with pytest.raises(ValueError):
+            statsdecor.incr('a.metric', tags=self.tags)
+
+    @patch('statsd.client.StatsClient.decr')
+    def test_decr_no_tag(self, mocked_super):
+        statsdecor.decr('a.metric')
+        mocked_super.assert_called_with(stat='a.metric', count=DEFAULT_VALUE, rate=DEFAULT_RATE)
+
+    def test_decr_with_tag(self):
+        with pytest.raises(ValueError):
+            statsdecor.decr('a.metric', tags=self.tags)
+
+    @patch('statsd.client.StatsClient.gauge')
+    def test_gauge_no_tag(self, mocked_super):
+        statsdecor.gauge('a.metric', value=DEFAULT_VALUE)
+        mocked_super.assert_called_with(stat='a.metric', value=DEFAULT_VALUE, rate=DEFAULT_RATE)
+
+    def test_gauge_with_tag(self):
+        with pytest.raises(ValueError):
+            statsdecor.gauge('a.metric', value=DEFAULT_VALUE, tags=self.tags)
+
+    @patch('statsd.client.StatsClient.timing')
+    def test_timing_no_tag(self, mocked_super):
+        statsdecor.timing('a.metric', delta=DEFAULT_VALUE)
+        mocked_super.assert_called_with(stat='a.metric', delta=DEFAULT_VALUE, rate=DEFAULT_RATE)
+
+    def test_timing_with_tag(self):
+        with pytest.raises(ValueError):
+            statsdecor.timing('a.metric', delta=DEFAULT_VALUE, tags=self.tags)
+
+    @patch('statsd.client.StatsClient.timer')
+    def test_timer_no_tag(self, mocked_super):
+        statsdecor.timer('a.metric')
+        mocked_super.assert_called_with(stat='a.metric')
+
+    def test_timer_with_tag(self):
+        with pytest.raises(ValueError):
+            statsdecor.timer('a.metric', tags=self.tags)
+
+
+class TestDogStatsdClient(object):
+    def setup(self):
+        self.tags = ['DogStatsd_does_tags!']
+        self.vendor = 'datadog'
+        statsdecor.configure(vendor=self.vendor)
+
+    @patch('datadog.dogstatsd.DogStatsd.increment')
+    def test_incr_no_tag(self, mocked_super):
+        statsdecor.incr('a.metric')
+        mocked_super.assert_called_with(metric='a.metric', value=DEFAULT_VALUE, tags=NO_TAGS, sample_rate=DEFAULT_RATE)
+
+    @patch('datadog.dogstatsd.DogStatsd.increment')
+    def test_incr_with_tag(self, mocked_super):
+        statsdecor.incr('a.metric',  tags=self.tags)
+        mocked_super.assert_called_with(metric='a.metric', value=DEFAULT_VALUE, tags=self.tags, sample_rate=DEFAULT_RATE)
+
+    @patch('datadog.dogstatsd.DogStatsd.decrement')
+    def test_decr_no_tag(self, mocked_super):
+        statsdecor.decr('a.metric')
+        mocked_super.assert_called_with(metric='a.metric', value=DEFAULT_VALUE, tags=NO_TAGS, sample_rate=DEFAULT_RATE)
+
+    @patch('datadog.dogstatsd.DogStatsd.decrement')
+    def test_decr_with_tag(self, mocked_super):
+        statsdecor.decr('a.metric', tags=self.tags)
+        mocked_super.assert_called_with(metric='a.metric', value=DEFAULT_VALUE, tags=self.tags, sample_rate=DEFAULT_RATE)
+
+    @patch('datadog.dogstatsd.DogStatsd.gauge')
+    def test_gauge_no_tag(self, mocked_super):
+        statsdecor.gauge('a.metric', value=DEFAULT_VALUE)
+        mocked_super.assert_called_with(metric='a.metric', value=DEFAULT_VALUE, tags=NO_TAGS, sample_rate=DEFAULT_RATE)
+
+    @patch('datadog.dogstatsd.DogStatsd.gauge')
+    def test_gauge_with_tag(self, mocked_super):
+        statsdecor.gauge('a.metric', value=DEFAULT_VALUE, tags=self.tags)
+        mocked_super.assert_called_with(metric='a.metric', value=DEFAULT_VALUE, tags=self.tags, sample_rate=DEFAULT_RATE)
+
+    @patch('datadog.dogstatsd.DogStatsd.timing')
+    def test_timing_no_tag(self, mocked_super):
+        statsdecor.timing('a.metric', delta=DEFAULT_VALUE)
+        mocked_super.assert_called_with(metric='a.metric', value=DEFAULT_VALUE, tags=NO_TAGS, sample_rate=DEFAULT_RATE)
+
+    @patch('datadog.dogstatsd.DogStatsd.timing')
+    def test_timing_with_tag(self, mocked_super):
+        statsdecor.timing('a.metric', delta=DEFAULT_VALUE, tags=self.tags)
+        mocked_super.assert_called_with(metric='a.metric', value=DEFAULT_VALUE, tags=self.tags, sample_rate=DEFAULT_RATE)
+
+    @patch('datadog.dogstatsd.DogStatsd.timed')
+    def test_timer_no_tag(self, mocked_super):
+        statsdecor.timer('a.metric')
+        mocked_super.assert_called_with(metric='a.metric', tags=NO_TAGS)
+
+    @patch('datadog.dogstatsd.DogStatsd.timed')
+    def test_timer_with_tag(self, mocked_super):
+        statsdecor.timer('a.metric', tags=self.tags)
+        mocked_super.assert_called_with(metric='a.metric', tags=self.tags)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,6 +1,14 @@
 import statsdecor.decorators as decorators
+import statsdecor
 from tests.conftest import stub_client
 from mock import MagicMock
+from statsdecor.clients import (
+    DogStatsdClient,
+    StatsdClient
+)
+
+
+NO_TAGS = None
 
 
 def assert_arguments(args, kwargs):
@@ -8,33 +16,75 @@ def assert_arguments(args, kwargs):
     assert {'key': 'value'} == kwargs
 
 
-def test_increment():
-    @decorators.increment('a.metric')
-    def test_fn(*args, **kwargs):
-        assert_arguments(args, kwargs)
+class BaseDecoratorTestCase(object):
 
-    with stub_client('statsdecor.decorators.client') as stub:
-        test_fn('some', 'thing', key='value')
-        stub.client.incr.assert_called_with('a.metric')
+    def test_increment__no_tags(self):
+        @decorators.increment('a.metric')
+        def test_fn(*args, **kwargs):
+            assert_arguments(args, kwargs)
 
+        with stub_client(self.client_class, 'statsdecor.decorators.client') as stub:
+            test_fn('some', 'thing', key='value')
+            stub.client.incr.assert_called_with('a.metric', tags=NO_TAGS)
 
-def test_decrement():
-    @decorators.decrement('a.metric')
-    def test_fn(*args, **kwargs):
-        assert_arguments(args, kwargs)
+    def test_increment__with_tags(self):
+        @decorators.increment('a.metric', tags=self.tags)
+        def test_fn(*args, **kwargs):
+            assert_arguments(args, kwargs)
 
-    with stub_client('statsdecor.decorators.client') as stub:
-        test_fn('some', 'thing', key='value')
-        stub.client.decr.assert_called_with('a.metric')
+        with stub_client(self.client_class, 'statsdecor.decorators.client') as stub:
+            test_fn('some', 'thing', key='value')
+            stub.client.incr.assert_called_with('a.metric', tags=self.tags)
 
+    def test_decrement__no_tags(self):
+        @decorators.decrement('a.metric')
+        def test_fn(*args, **kwargs):
+            assert_arguments(args, kwargs)
 
-def test_timed():
-    @decorators.timed('a.metric')
-    def test_fn(*args, **kwargs):
-        assert_arguments(args, kwargs)
+        with stub_client(self.client_class, 'statsdecor.decorators.client') as stub:
+            test_fn('some', 'thing', key='value')
+            stub.client.decr.assert_called_with('a.metric', tags=NO_TAGS)
 
-    with stub_client('statsdecor.decorators.client') as stub:
-        # Stub out the timing context manager.
-        stub.client.timer.return_value = MagicMock()
-        test_fn('some', 'thing', key='value')
-        stub.client.timer.assert_called_with('a.metric')
+    def test_decrement__with_tags(self):
+        @decorators.decrement('a.metric', tags=self.tags)
+        def test_fn(*args, **kwargs):
+            assert_arguments(args, kwargs)
+
+        with stub_client(self.client_class, 'statsdecor.decorators.client') as stub:
+            test_fn('some', 'thing', key='value')
+            stub.client.decr.assert_called_with('a.metric', tags=self.tags)
+
+    def test_timed__no_tags(self):
+        @decorators.timed('a.metric')
+        def test_fn(*args, **kwargs):
+            assert_arguments(args, kwargs)
+
+        with stub_client(self.client_class, 'statsdecor.decorators.client') as stub:
+            # Stub out the timing context manager.
+            stub.client.timer.return_value = MagicMock()
+            test_fn('some', 'thing', key='value')
+            stub.client.timer.assert_called_with('a.metric', tags=NO_TAGS)
+
+    def test_timed__with_tags(self):
+        @decorators.timed('a.metric', tags=self.tags)
+        def test_fn(*args, **kwargs):
+            assert_arguments(args, kwargs)
+
+        with stub_client(self.client_class, 'statsdecor.decorators.client') as stub:
+            # Stub out the timing context manager.
+            stub.client.timer.return_value = MagicMock()
+            test_fn('some', 'thing', key='value')
+            stub.client.timer.assert_called_with('a.metric', tags=self.tags)
+
+class TestStatsdDefaultClient(BaseDecoratorTestCase):
+    def setup(self):
+        self.tags = ['StatsClient_doesnt_do_tags!']
+        self.client_class = StatsdClient
+        statsdecor.configure()
+
+class TestDogStatsdClient(BaseDecoratorTestCase):
+    def setup(self):
+        self.tags = ['DogStatsd_does_tags!']
+        self.vendor = 'datadog'
+        self.client_class = DogStatsdClient
+        statsdecor.configure(vendor=self.vendor)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,69 +1,92 @@
 import statsdecor
 import statsd
 from tests.conftest import stub_client
+from statsdecor.clients import (
+    DogStatsdClient,
+    StatsdClient
+)
+
+class BaseFunctionTestCase(object):
+    def test_incr(self):
+        with stub_client(self.client_class) as stub:
+            statsdecor.incr('a.metric')
+            stub.client.incr.assert_called_with('a.metric', 1, 1, None)
+
+    def test_incr__with_value_and_rate(self):
+        with stub_client(self.client_class) as stub:
+            statsdecor.incr('a.metric', 9, 0.1)
+            stub.client.incr.assert_called_with('a.metric', 9, 0.1, None)
+
+    def test_decr(self):
+        with stub_client(self.client_class) as stub:
+            statsdecor.decr('a.metric')
+            stub.client.decr.assert_called_with('a.metric', 1, 1, None)
+
+    def test_decr__with_value_and_rate(self):
+        with stub_client(self.client_class) as stub:
+            statsdecor.decr('a.metric', 9, 0.1)
+            stub.client.decr.assert_called_with('a.metric', 9, 0.1, None)
+
+    def test_gauge(self):
+        with stub_client(self.client_class) as stub:
+            statsdecor.gauge('a.metric', 8)
+            stub.client.gauge.assert_called_with('a.metric', 8, 1, None)
+
+    def test_gauge__with_value_and_rate(self):
+        with stub_client(self.client_class) as stub:
+            statsdecor.gauge('a.metric', 9, 0.1)
+            stub.client.gauge.assert_called_with('a.metric', 9, 0.1, None)
+
+    def test_timer(self):
+        with stub_client(self.client_class) as stub:
+            statsdecor.timer('a.metric')
+            assert stub.client.timer.called, 'Should be called'
+
+    def test_timing(self):
+        with stub_client(self.client_class) as stub:
+            statsdecor.timing('a.metric', 314159265359)
+            stub.client.timing.assert_called_with('a.metric', 314159265359, 1, None)
+
+    def test_timing__with_value_and_rate(self):
+        with stub_client(self.client_class) as stub:
+            statsdecor.timing('a.metric', 314159265359, 0.1)
+            stub.client.timing.assert_called_with('a.metric', 314159265359, 0.1, None)
+
+    def test_configure_and_create(self):
+        raise NotImplementedError()
 
 
-def test_client_error_no_config(monkeypatch):
-    # When the client hasn't been initialized,
-    # an exception should be raised by client()
-    monkeypatch.setattr(statsdecor, '_stats_client', None)
-    client = statsdecor.client()
-    assert isinstance(client, statsd.StatsClient)
+class TestStatsdDefaultClient(BaseFunctionTestCase):
+    def setup(self):
+        self.client_class = StatsdClient
+        statsdecor.configure(vendor='')
+
+    def test_client_error_no_config(self, monkeypatch):
+        # TODO: DIG UP HISTORY what is the below referring to ?
+        # When the client hasn't been initialized,
+        # an exception should be raised by client()
+        monkeypatch.setattr(statsdecor, '_stats_client', None)
+        client = statsdecor.client()
+        assert isinstance(client, statsd.StatsClient)
+
+    def test_configure_and_create(self):
+        statsdecor.configure(port=9999)
+        client = statsdecor.client()
+        assert client._addr[1] == 9999, 'port should match'
 
 
-def test_incr():
-    with stub_client() as stub:
-        statsdecor.incr('a.metric')
-        stub.client.incr.assert_called_with('a.metric', 1, 1)
+class TestDogStatsdClient(BaseFunctionTestCase):
+    def setup(self):
+        self.vendor = 'datadog'
+        self.client_class = DogStatsdClient
+        statsdecor.configure(vendor=self.vendor)
 
+    def test_configure_and_create(self):
+        statsdecor.configure(port=9999)
+        client = statsdecor.client()
+        assert client.port == 9999, 'port should match'
 
-def test_incr__with_value_and_rate():
-    with stub_client() as stub:
-        statsdecor.incr('a.metric', 9, 0.1)
-        stub.client.incr.assert_called_with('a.metric', 9, 0.1)
-
-
-def test_decr():
-    with stub_client() as stub:
-        statsdecor.decr('a.metric')
-        stub.client.decr.assert_called_with('a.metric', 1, 1)
-
-
-def test_decr__with_value_and_rate():
-    with stub_client() as stub:
-        statsdecor.decr('a.metric', 9, 0.1)
-        stub.client.decr.assert_called_with('a.metric', 9, 0.1)
-
-
-def test_gauge():
-    with stub_client() as stub:
-        statsdecor.gauge('a.metric', 8)
-        stub.client.gauge.assert_called_with('a.metric', 8, 1)
-
-
-def test_gauge__with_value_and_rate():
-    with stub_client() as stub:
-        statsdecor.gauge('a.metric', 9, 0.1)
-        stub.client.gauge.assert_called_with('a.metric', 9, 0.1)
-
-
-def test_timer():
-    with stub_client() as stub:
-        statsdecor.timer('a.metric')
-        assert stub.client.timer.called, 'Should be called'
-
-
-def test_configure_and_create():
-    statsdecor.configure(port=9999)
-    client = statsdecor.client()
-    assert client._addr[1] == 9999, 'port should match'
-
-def test_timing():
-    with stub_client() as stub:
-        statsdecor.timing('a.metric', 314159265359)
-        stub.client.timing.assert_called_with('a.metric', 314159265359, 1)
-
-def test_timing__with_value_and_rate():
-    with stub_client() as stub:
-        statsdecor.timing('a.metric', 314159265359, 0.1)
-        stub.client.timing.assert_called_with('a.metric', 314159265359, 0.1)
+    def test_configure_and_create__with_maxudpsize(self):
+        statsdecor.configure(maxudpsize=512)
+        client = statsdecor.client()
+        assert client.port == 9999, 'port should match'

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -62,10 +62,7 @@ class TestStatsdDefaultClient(BaseFunctionTestCase):
         self.client_class = StatsdClient
         statsdecor.configure(vendor='')
 
-    def test_client_error_no_config(self, monkeypatch):
-        # TODO: DIG UP HISTORY what is the below referring to ?
-        # When the client hasn't been initialized,
-        # an exception should be raised by client()
+    def test_client_created_if_no_existing_client__with_no_config(self, monkeypatch):
         monkeypatch.setattr(statsdecor, '_stats_client', None)
         client = statsdecor.client()
         assert isinstance(client, statsd.StatsClient)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,5 +1,6 @@
 import statsdecor
 import statsd
+from datadog import DogStatsd
 from tests.conftest import stub_client
 from statsdecor.clients import (
     DogStatsdClient,
@@ -74,6 +75,11 @@ class TestStatsdDefaultClient(BaseFunctionTestCase):
         client = statsdecor.client()
         assert client._addr[1] == 9999, 'port should match'
 
+    def test_configure_and_create__with_fields_not_in_whitelist(self):
+        statsdecor.configure(random=1234, field=33, port=1234)
+        client = statsdecor.client()
+        assert isinstance(client, statsd.StatsClient)
+        assert client._addr[1] == 1234, 'port should match'
 
 class TestDogStatsdClient(BaseFunctionTestCase):
     def setup(self):
@@ -86,7 +92,12 @@ class TestDogStatsdClient(BaseFunctionTestCase):
         client = statsdecor.client()
         assert client.port == 9999, 'port should match'
 
-    def test_configure_and_create__with_maxudpsize(self):
+    def test_configure_and_create__with_prefix(self):
+        statsdecor.configure(prefix='statsdecor')
+        client = statsdecor.client()
+        assert client.namespace == 'statsdecor', 'namespace should match prefix'
+
+    def test_configure_and_create__with_fields_not_in_whitelist(self):
         statsdecor.configure(maxudpsize=512)
         client = statsdecor.client()
-        assert client.port == 9999, 'port should match'
+        assert isinstance(client, DogStatsd)


### PR DESCRIPTION
@markstory 

We want to support datadog so we can use tags. 
Instead of using the datadog lib specifically, for each of our services, this change makes it easier for other apps to switch over to datadog.