### PR TITLE
Drop support for python 3.2, add support for python 3.5, and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: python
 
 python:
  - "2.7"
- - "3.2"
  - "3.3"
  - "3.4"
+ - "3.5"
+ - "3.6"
 
 env:
   global:


### PR DESCRIPTION
Requests library (which datadog's python lib uses) does not support python 3.2. (So our tests are failing)

Adding support for 3.5 and 3.6