### PR TITLE
Solves an issue with decorators in statsdecor 0.3.3

### DIFF
--- a/statsdecor/clients.py
+++ b/statsdecor/clients.py
@@ -24,7 +24,7 @@ class DogStatsdClient(DogStatsd):
         super(DogStatsdClient, self).timing(metric=name, value=value, tags=tags, sample_rate=rate)
 
     def timer(self, name, tags=None):
-        super(DogStatsdClient, self).timed(metric=name, tags=tags)
+        return super(DogStatsdClient, self).timed(metric=name, tags=tags)
 
 
 class StatsdClient(StatsClient):
@@ -54,7 +54,7 @@ class StatsdClient(StatsClient):
 
     def timer(self, name, tags=None):
         self._assert_no_tags(tags)
-        super(StatsdClient, self).timer(stat=name)
+        return super(StatsdClient, self).timer(stat=name)
 
     def _assert_no_tags(self, tags):
         if tags:

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,6 +1,8 @@
 import statsdecor
 import pytest
 from mock import patch, Mock
+from datadog.dogstatsd.context import TimedContextManagerDecorator as datadogTimer
+from statsd.client import Timer as statsdTimer
 
 
 DEFAULT_RATE=1
@@ -49,10 +51,8 @@ class TestStatsdDefaultClient(object):
         with pytest.raises(ValueError):
             statsdecor.timing('a.metric', delta=DEFAULT_VALUE, tags=self.tags)
 
-    @patch('statsd.client.StatsClient.timer')
-    def test_timer_no_tag(self, mocked_super):
-        statsdecor.timer('a.metric')
-        mocked_super.assert_called_with(stat='a.metric')
+    def test_timer_no_tag(self):
+        assert isinstance(statsdecor.timer('a.metric'), statsdTimer)
 
     def test_timer_with_tag(self):
         with pytest.raises(ValueError):
@@ -105,12 +105,8 @@ class TestDogStatsdClient(object):
         statsdecor.timing('a.metric', delta=DEFAULT_VALUE, tags=self.tags)
         mocked_super.assert_called_with(metric='a.metric', value=DEFAULT_VALUE, tags=self.tags, sample_rate=DEFAULT_RATE)
 
-    @patch('datadog.dogstatsd.DogStatsd.timed')
-    def test_timer_no_tag(self, mocked_super):
-        statsdecor.timer('a.metric')
-        mocked_super.assert_called_with(metric='a.metric', tags=NO_TAGS)
+    def test_timer_no_tag(self):
+        assert isinstance(statsdecor.timer('a.metric'), datadogTimer)
 
-    @patch('datadog.dogstatsd.DogStatsd.timed')
-    def test_timer_with_tag(self, mocked_super):
-        statsdecor.timer('a.metric', tags=self.tags)
-        mocked_super.assert_called_with(metric='a.metric', tags=self.tags)
+    def test_timer_with_tag(self):
+        assert isinstance(statsdecor.timer('a.metric', tags=self.tags), datadogTimer)

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,8 +1,8 @@
 import statsdecor
 import pytest
 from mock import patch, Mock
-from datadog.dogstatsd.context import TimedContextManagerDecorator as datadogTimer
-from statsd.client import Timer as statsdTimer
+from datadog.dogstatsd.context import TimedContextManagerDecorator as DatadogTimer
+from statsd.client import Timer as StatsdTimer
 
 
 DEFAULT_RATE=1
@@ -52,7 +52,7 @@ class TestStatsdDefaultClient(object):
             statsdecor.timing('a.metric', delta=DEFAULT_VALUE, tags=self.tags)
 
     def test_timer_no_tag(self):
-        assert isinstance(statsdecor.timer('a.metric'), statsdTimer)
+        assert isinstance(statsdecor.timer('a.metric'), StatsdTimer)
 
     def test_timer_with_tag(self):
         with pytest.raises(ValueError):
@@ -106,7 +106,7 @@ class TestDogStatsdClient(object):
         mocked_super.assert_called_with(metric='a.metric', value=DEFAULT_VALUE, tags=self.tags, sample_rate=DEFAULT_RATE)
 
     def test_timer_no_tag(self):
-        assert isinstance(statsdecor.timer('a.metric'), datadogTimer)
+        assert isinstance(statsdecor.timer('a.metric'), DatadogTimer)
 
     def test_timer_with_tag(self):
-        assert isinstance(statsdecor.timer('a.metric', tags=self.tags), datadogTimer)
+        assert isinstance(statsdecor.timer('a.metric', tags=self.tags), DatadogTimer)


### PR DESCRIPTION
The Timer ~and Timing~ functions were not returned from each client's respective library, they would not function correctly.
Updated tests to make sure this doesn't happen again.


[statsd timer][statsd timer] && [datadog timed][datadog timer]  (which is timer in our implementation)


**Edit**: The `timing` functions do not need to return values. [statsd timing][statsd timing] && [datadog timing][datadog timing]

[statsd timer]: https://github.com/jsocol/pystatsd/blob/master/statsd/client.py#L94-L95
[datadog timer]: https://github.com/DataDog/datadogpy/blob/master/datadog/dogstatsd/base.py#L210-L236

[statsd timing]: https://github.com/jsocol/pystatsd/blob/master/statsd/client.py#L97-L99
[datadog timing]: https://github.com/DataDog/datadogpy/blob/master/datadog/dogstatsd/base.py#L202-L208