### PR TITLE
Changed function signature for DogStatsdClient.timing to match DD client

### DIFF
--- a/statsdecor/__init__.py
+++ b/statsdecor/__init__.py
@@ -97,4 +97,4 @@ def timing(name, delta, rate=1, tags=None):
     >>> import statsdecor
     >>> statsdecor.timing('my.metric', 314159265359)
     """
-    return client().timing(name, delta, rate, tags)
+    return client().timing(name, delta, rate=rate, tags=tags)

--- a/statsdecor/clients.py
+++ b/statsdecor/clients.py
@@ -20,7 +20,7 @@ class DogStatsdClient(DogStatsd):
     def gauge(self, name, value=1, rate=1, tags=None):
         super(DogStatsdClient, self).gauge(metric=name, value=value, tags=tags, sample_rate=rate)
 
-    def timing(self, name, value, rate=1, tags=None):
+    def timing(self, name, value, tags=None, rate=1):
         super(DogStatsdClient, self).timing(metric=name, value=value, tags=tags, sample_rate=rate)
 
     def timer(self, name, tags=None):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -46,12 +46,22 @@ class BaseFunctionTestCase(object):
     def test_timing(self):
         with stub_client(self.client_class) as stub:
             statsdecor.timing('a.metric', 314159265359)
-            stub.client.timing.assert_called_with('a.metric', 314159265359, 1, None)
+            stub.client.timing.assert_called_with(
+                'a.metric',
+                314159265359,
+                rate=1,
+                tags=None
+            )
 
     def test_timing__with_value_and_rate(self):
         with stub_client(self.client_class) as stub:
             statsdecor.timing('a.metric', 314159265359, 0.1)
-            stub.client.timing.assert_called_with('a.metric', 314159265359, 0.1, None)
+            stub.client.timing.assert_called_with(
+                'a.metric',
+                314159265359,
+                rate=0.1,
+                tags=None
+            )
 
     def test_configure_and_create(self):
         raise NotImplementedError()


### PR DESCRIPTION
tl;dr - DD client does not use kwargs and the actual ordering of the parameters is `name, value, tags, rate`

The `dogstatsd` `timing` method calls the `statsd.timing` [method like so](https://github.com/DataDog/datadogpy/blob/v0.17.0/datadog/dogstatsd/context.py#L72):
`self.statsd.timing(self.metric, elapsed, self.tags, self.sample_rate)`

But, `DogStatsdClient.timing` [function signature is](https://github.com/freshbooks/statsdecor/blob/master/statsdecor/clients.py#L23):
`def timing(self, name, value, rate=1, tags=None):`

Since the method is called using positional args instead of kwargs, the `DogStatsdClient.timing` is called with the wrong values. Since `DogStatsdClient` should remain compatible with the `dogstatsd` library, I made the change in the `DogStatsdClient`'s function signature.

See code here: https://github.com/DataDog/datadogpy/blob/v0.17.0/datadog/dogstatsd/context.py#L72

Refs TNG-000