### PR TITLE
Welcome StatsContext!  Tagged timing metrics: easy

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@ pytest
 flake8
 python-coveralls
 coverage
+nose
 mock

--- a/statsdecor/context.py
+++ b/statsdecor/context.py
@@ -1,0 +1,105 @@
+import logging
+from time import time
+
+
+_log = logging.getLogger(__name__)
+
+from statsdecor import client
+
+class StatsContext(object):
+    """
+        Usage example:
+
+        class ThingyStatsContext(StatsContext):
+            def __init__(self, tags=None):
+                tags = tags or []
+                tags += ['service:thingy']
+                super(ThingyStatsContext, self).__self__('thingy_client', tags=tags)
+
+            def exit_hook(self, exc_type, exc_val, exc_tb):
+                if isinstance(exc_val, PermissionDenied):
+                    self.add_tags('result', 'permissiondenied')
+                elif exc_val is not None:
+                    self.add_tags('result', 'exception')
+                else:
+                    self.add_tags('result', 'success')
+
+        def call_thing():
+            with ThingyStatsContext() as stats:
+                result = CallThingy()
+                stats.add_tags('status_code', 'result["status_code"]')
+    """
+
+    def __init__(self, metric_base, tags=None, stats=None):
+        """
+            metric_base is add to the beginning of the "attempted", "duration", and "completed" metrics emited.
+
+            tags is a list of string tags (in the format ["key:value", ..])
+        """
+        self._metric_base = metric_base
+
+        self._tags = tags or []
+
+        self._metric_attempted = '{}.attempted'.format(self._metric_base)
+        self._metric_duration = '{}.duration'.format(self._metric_base)
+        self._metric_completed = '{}.completed'.format(self._metric_base)
+
+        self._stats = stats or client()
+
+        self._elapsed = None
+
+    def add_tag(self, key, value):
+        """ Adds a datadog tag to the metrics emitted.
+
+        Syntatic sugar equivalent to:
+
+            add_tags('{}.{}'.format(key, value))
+        """
+
+        self.add_tags('{}:{}'.format(key, value))
+
+    def add_tags(self, *tags):
+        """ Adds a datadog tag to the metrics emitted.
+
+        Tags added before the context begins are included in all metrics.
+        Tags added before the context finished are included in the 'completed' and 'duration' metrics.
+        """
+        self._tags.extend(tags)
+
+    def exit_hook(self, exc_type, exc_val, exc_tb):
+        """ Called on exit.  By default does nothing.
+
+        Child classes should override this method and translate the exceptions thrown
+        (or lack of exceptions thrown) into metric tags.
+        """
+
+        pass
+
+    def _start_timer(self):
+        self._start = time()
+
+    def _stop_timer(self):
+        self._elapsed = time() - self._start
+
+    def __enter__(self):
+        self._stats.increment(self._metric_attempted, tags=self._tags)
+        self._start_timer()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._stop_timer()
+        try:
+            self.exit_hook(exc_type, exc_val, exc_tb)
+        except Exception:
+            # swallow errors--we don't want to complicate exception handling in the main
+            # program flow.
+            _log.exception("warning: Unhandled expcetion in StatsContext exit hook (ignoring)")
+
+        self._stats.timing(self._metric_duration, self._elapsed, tags=self._tags)
+        self._stats.increment(self._metric_completed, tags=self._tags)
+        _log.info('Metrics sent: {}, tags={}, elapsed time={}'.format(
+            self._metric_base,
+            ','.join(self._tags),
+            self._elapsed
+        ))
+        return False

--- a/statsdecor/context.py
+++ b/statsdecor/context.py
@@ -1,10 +1,10 @@
+from statsdecor import client
 import logging
 from time import time
 
 
 _log = logging.getLogger(__name__)
 
-from statsdecor import client
 
 class StatsContext(object):
     """

--- a/statsdecor/context.py
+++ b/statsdecor/context.py
@@ -26,7 +26,7 @@ class StatsContext(object):
 
         def call_thing():
             with ThingyStatsContext() as stats:
-                result = CallThingy()
+                result = thingy_external_call()
                 stats.add_tags('status_code', 'result["status_code"]')
     """
 
@@ -97,7 +97,7 @@ class StatsContext(object):
 
         self._stats.timing(self._metric_duration, self._elapsed, tags=self._tags)
         self._stats.increment(self._metric_completed, tags=self._tags)
-        _log.info('Metrics sent: {}, tags={}, elapsed time={}'.format(
+        _log.debug('Metrics sent: {}, tags={}, elapsed time={}'.format(
             self._metric_base,
             ','.join(self._tags),
             self._elapsed

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,125 @@
+import statsdecor
+from statsdecor.context import StatsContext
+from nose.tools import eq_, ok_
+from mock import patch
+
+
+class _DerivedContext(StatsContext):
+    def __init__(self):
+        super(_DerivedContext, self).__init__('test.hello')
+        self.add_tag('always', 'yup')
+
+    def exit_hook(self, a, b, c):
+        self.add_tag('exit', 'yup')
+        if b is None:
+            self.add_tag('exception', 'none')
+        else:
+            self.add_tag('exception', 'yes')
+
+
+class _BadContext(StatsContext):
+    def __init__(self):
+        super(_BadContext, self).__init__('test.badly')
+        self.add_tag('always', 'badly')
+
+    def exit_hook(self, a, b, c):
+        raise Exception("derp derp derp")
+
+
+class _TestException(Exception):
+    pass
+
+
+class TestStatsContext(object):
+    def setup(self):
+        self.tags = ['DogStatsd_does_tags!']
+        self.vendor = 'datadog'
+        statsdecor.configure(vendor=self.vendor)
+        # DELETE me
+        self.mock_current_app = None
+
+    @patch('datadog.dogstatsd.DogStatsd.increment')
+    @patch('datadog.dogstatsd.DogStatsd.timing')
+    def test_naked(self, timing, increment):
+        s = StatsContext('test.naked', tags=['invocation:tag'])
+        with s as s2:
+            increment.assert_called_with(
+                'test.naked.attempted',
+                tags=['invocation:tag']
+            )
+            s2.add_tag('newtag', 'yes')
+
+        increment.assert_called_with(
+            'test.naked.completed',
+            tags=['invocation:tag', 'newtag:yes']
+        )
+        print(repr(timing.call_args))
+        print(repr(timing.call_args[0]))
+        timing.assert_called()
+        eq_(timing.call_args[1]['metric'], 'test.naked.duration')
+        ok_(timing.call_args[1]['value'] > 0)
+        eq_(timing.call_args[1]['tags'], ['invocation:tag', 'newtag:yes'])
+
+    @patch('datadog.dogstatsd.DogStatsd.increment')
+    @patch('datadog.dogstatsd.DogStatsd.timing')
+    def test_derived_greenpath(self, timing, increment):
+        with _DerivedContext() as s2:
+            increment.assert_called_with(
+                'test.hello.attempted',
+                tags=['always:yup']
+            )
+            s2.add_tag('newtag', 'yes')
+
+        expected_tags = ['always:yup', 'newtag:yes', 'exit:yup',  'exception:none']
+        increment.assert_called_with(
+            'test.hello.completed',
+            tags=expected_tags
+        )
+        print(repr(timing))
+        eq_(timing.call_args[1]['metric'], 'test.hello.duration')
+        ok_(timing.call_args[1]['value'] > 0)
+        eq_(timing.call_args[1]['tags'], expected_tags)
+
+    @patch('datadog.dogstatsd.DogStatsd.increment')
+    @patch('datadog.dogstatsd.DogStatsd.timing')
+    def test_derived_exception(self, timing, increment):
+        try:
+            with _DerivedContext() as s2:
+                increment.assert_called_with(
+                    'test.hello.attempted',
+                    tags=['always:yup']
+                )
+                s2.add_tag('newtag', 'yes')
+                raise _TestException("this didn't go well")
+        except _TestException:
+            ok_(True, 'exception passed through')
+        else:
+            ok_(False, 'exception swallowed by context manager')  # pragma: nocover
+
+        expected_tags = ['always:yup', 'newtag:yes', 'exit:yup',  'exception:yes']
+        increment.assert_called_with(
+            'test.hello.completed',
+            tags=expected_tags
+        )
+        eq_(timing.call_args[1]['metric'], 'test.hello.duration')
+        ok_(timing.call_args[1]['value'] > 0)
+        eq_(timing.call_args[1]['tags'], expected_tags)
+
+    @patch('datadog.dogstatsd.DogStatsd.increment')
+    @patch('datadog.dogstatsd.DogStatsd.timing')
+    def test_derived_raised_exception_itself(self, timing, increment):
+        with _BadContext() as s2:
+            increment.assert_called_with(
+                'test.badly.attempted',
+                tags=['always:badly']
+            )
+            s2.add_tag('newtag', 'yes')
+
+        expected_tags = ['always:badly', 'newtag:yes']
+        increment.assert_called_with(
+            'test.badly.completed',
+            tags=expected_tags
+        )
+        eq_(timing.call_args[1]['metric'], 'test.badly.duration')
+        ok_(timing.call_args[1]['value'] > 0)
+        eq_(timing.call_args[1]['tags'], expected_tags)


### PR DESCRIPTION
StatsContext make it easy to collect timing metrics and classify those timing metrics.  For example, if you want to time an external call and tag if it timed out, you can do that with StatsContext:

```
# first, make a context that interprets exceptions into tags
        class ThingyStatsContext(StatsContext):
            def __init__(self, **kwargs):
                super(ThingyStatsContext, self).__self__('thingy_client', **kwargs)

            def exit_hook(self, exc_type, exc_val, exc_tb):
                if isinstance(exc_val, PermissionDenied):
                    self.add_tag('result', 'permissiondenied')
                elif isinstance(exc_val, Timeout):
                    self.add_tag('result', 'timeout')
                elif exc_val is not None:
                    self.add_tag('result', 'exception')
                else:
                    self.add_tag('result', 'success')
```

Next step use it:

```
        def do_a_thing():
            with ThingyStatsContext(tags=['a:tag']) as stats:
                result = some_external_call()
                stats.add_tag('status_code', 'result["status_code"]')
```

This will emit these metrics:

* counter `thingy_client.attempted` with tags "a:tag"
* timer `thingy_client.duration` with tags "a:tag", "result:success", "status_code:200" 
* counter `thingy_client.attempted` with tags "a:tag", "result:success", "status_code:200" 

Then, you can graph the average *successful* response time without the "permission denied" and "timeout" skewing the results.
