### PR TITLE
✨ Add method to check for tag support

### DIFF
--- a/statsdecor/__init__.py
+++ b/statsdecor/__init__.py
@@ -55,6 +55,10 @@ def client():
         configure({})
     return _stats_client
 
+def client_supports_tags():
+    if isinstance(client(), DogStatsdClient):
+        return True
+    return False
 
 def incr(name, value=1, rate=1, tags=None):
     """Increment a metric by value.

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -82,12 +82,18 @@ class TestStatsdDefaultClient(BaseFunctionTestCase):
         statsdecor.configure(port=9999)
         client = statsdecor.client()
         assert client._addr[1] == 9999, 'port should match'
+        assert not statsdecor.client_supports_tags()
 
     def test_configure_and_create__with_fields_not_in_whitelist(self):
         statsdecor.configure(random=1234, field=33, port=1234)
         client = statsdecor.client()
         assert isinstance(client, statsd.StatsClient)
         assert client._addr[1] == 1234, 'port should match'
+
+    def test_should_not_support_tags(self):
+        statsdecor.configure(port=9999)
+        client = statsdecor.client()
+        assert not statsdecor.client_supports_tags()
 
 
 class TestDogStatsdClient(BaseFunctionTestCase):
@@ -110,3 +116,8 @@ class TestDogStatsdClient(BaseFunctionTestCase):
         statsdecor.configure(maxudpsize=512)
         client = statsdecor.client()
         assert isinstance(client, DogStatsd)
+
+    def test_should_support_tags(self):
+        statsdecor.configure(port=9999)
+        client = statsdecor.client()
+        assert statsdecor.client_supports_tags()


### PR DESCRIPTION
The datadog statsd client supports tags but the regular one does not. We have cases where we want to add tags in shared libraries that causes errors in services that do not use the datadog client.

Adding a method to report on the tag support of the instantiated client
so that we can guard these cases.

See SLAPI-278